### PR TITLE
Added script

### DIFF
--- a/custom.js
+++ b/custom.js
@@ -1,0 +1,10 @@
+// Add a click event to the body to handle navigation when clicking outside the image
+document.body.addEventListener('click', (event) => {
+    // Check if the click was not directly on the image
+    const isOutsideImage = event.target.tagName !== 'IMG';
+
+    // If the click was outside the image, navigate back to the previous page in the browser history
+    if (isOutsideImage) {
+        window.history.back();
+    }
+});

--- a/functions.php
+++ b/functions.php
@@ -19,6 +19,18 @@ function hideo_styles() {
 }
 add_action( 'wp_enqueue_scripts', 'hideo_styles' );
 
+/* -----------------------------------------------------------------------------------------------
+   ENQUEUE CUSTOM SCRIPTS
+--------------------------------------------------------------------------------------------------- */
+
+function enqueue_custom_scripts() {
+    wp_register_script('custom-scripts', get_template_directory_uri() . '/custom.js', array('jquery'), null, true);
+    wp_enqueue_script('custom-scripts');
+}
+
+// Hook into the wp_enqueue_scripts action
+add_action('wp_enqueue_scripts', 'enqueue_custom_scripts');
+
 
 /*	-----------------------------------------------------------------------------------------------
 	REGISTER BLOCK STYLES


### PR DESCRIPTION
When opening an image, there's only an option to zoom in on the first click and zoom out on the second click. However, the only way to go back to the previous view is by clicking the browser's back button.

--

It's just a small detail, but this script adds the natural option to go back to the previous view by clicking outside the image.

--

The script would handle the case where there is no previous view of the website in the browser tab by redirecting to the home page after the click. This event hasn't been added since it's an unusual situation – it would only occur when sharing a direct image link or manually opening an image in a new tab.